### PR TITLE
Mark data as public

### DIFF
--- a/catalog-info-component.yaml
+++ b/catalog-info-component.yaml
@@ -8,7 +8,7 @@ metadata:
       url: https://github.com/cultureamp/delayed_job
   tags:
     - camp-engagement
-    - data-none
+    - data-public
     - users-internal
   annotations:
     github.com/project-slug: cultureamp/delayed_job


### PR DESCRIPTION
Making the data classification for this open-source repo "public" after a chat with @bmendes3 who has been auditing some of our public repos.