### PR TITLE
Replace ActiveSupport::ProxyObject with BasicObject for Rails 8 compatibility

### DIFF
--- a/lib/delayed/compatibility.rb
+++ b/lib/delayed/compatibility.rb
@@ -3,24 +3,12 @@ require 'active_support/version'
 module Delayed
   module Compatibility
     if ActiveSupport::VERSION::MAJOR >= 4
-      require 'active_support/proxy_object'
-
       def self.executable_prefix
         'bin'
       end
-
-      def self.proxy_object_class
-        ActiveSupport::ProxyObject
-      end
     else
-      require 'active_support/basic_object'
-
       def self.executable_prefix
         'script'
-      end
-
-      def self.proxy_object_class
-        ActiveSupport::BasicObject
       end
     end
   end

--- a/lib/delayed/message_sending.rb
+++ b/lib/delayed/message_sending.rb
@@ -1,5 +1,15 @@
 module Delayed
-  class DelayProxy < Delayed::Compatibility.proxy_object_class
+  class DelayProxy < BasicObject
+    # What additional methods exist on BasicObject has changed over time
+    (::BasicObject.instance_methods - [:__id__, :__send__, :instance_eval, :instance_exec]).each do |method|
+      undef_method method
+    end
+
+    # Let DelayProxy raise exceptions.
+    def raise(*args)
+      ::Object.send(:raise, *args)
+    end
+
     def initialize(payload_class, target, options)
       @payload_class = payload_class
       @target = target


### PR DESCRIPTION
## Purpose

Add Rails 8 compatibility to delayed_job.

## Context

Rails 8 introduced breaking changes that prevent delayed_job from working:
- `ActiveSupport::ProxyObject` was deprecated in Rails 7.1 and **removed** in Rails 8
- The existing gemspec and Gemfile capped dependency versions at `< 8.0`

## Changes

- **Replace `ActiveSupport::ProxyObject` with `BasicObject`** — `DelayProxy` now inherits from `BasicObject` directly, undefining unnecessary methods to preserve the same minimal proxy interface. The `Delayed::Compatibility.proxy_object_class` helper is removed along with the `active_support/proxy_object` and `active_support/basic_object` requires (`lib/delayed/compatibility.rb`, `lib/delayed/message_sending.rb`)
- **Bump dependency upper bounds to `< 9.0`** — Updates `activesupport`, `railties`, `actionmailer`, and `activerecord` constraints in both `delayed_job.gemspec` and `Gemfile`
- **Bump RuboCop to 1.75.2** — Required for Ruby 3.4 compatibility (`Gemfile`)
- **Upgrade CI cache action** — `actions/cache@v1` → `actions/cache@v4` (`.github/workflows/rubocop.yml`)

## Verification

- Existing specs should continue to pass on Rails 6+/7+ as `BasicObject` has been available since Ruby 1.9
- Verify CI passes against Rails 8